### PR TITLE
Add FreeBSD Package Mention to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ brew install cloudquery/tap/cloudquery
 brew upgrade cloudquery
 ```
 
+FreeBSD
+```shell script
+# via packages
+pkg install cloudquery
+# via Ports
+cd /usr/ports/net/cloudquery
+make config-recursive install clean
+```
+
 ## Quick Start
 
 ### Running


### PR DESCRIPTION
I maintain the FreeBSD Port/Package for cloudquery. We should mention it in README.md.